### PR TITLE
Fixes

### DIFF
--- a/module-service/src/main/java/ma/enset/moduleservice/client/ElementClient.java
+++ b/module-service/src/main/java/ma/enset/moduleservice/client/ElementClient.java
@@ -18,7 +18,7 @@ public interface ElementClient {
     ResponseEntity<List<ModuleResponse.Element>> getElementsByCodeModule(@PathVariable("codeModule") String codeModule);
 
     @GetExchange(url = "/bulk")
-    ResponseEntity<List<ModuleResponse>> getElementsByCodesModule(@RequestParam Set<String> codesModule);
+    ResponseEntity<List<ModuleResponse>> getElementsByCodesModule(@RequestParam("codesModule") Set<String> codesModule);
 
     @DeleteExchange(url = "/{codeModule}")
     ResponseEntity<Void> deleteElementsByCodeModule(@PathVariable("codeModule") String codeModule);

--- a/module-service/src/main/java/ma/enset/moduleservice/service/ModuleServiceImpl.java
+++ b/module-service/src/main/java/ma/enset/moduleservice/service/ModuleServiceImpl.java
@@ -163,7 +163,7 @@ public class ModuleServiceImpl implements ModuleService {
 
         ModulePagingResponse response = mapper.toPagingResponse(repository.findAll(PageRequest.of(page, size)));
 
-        if (includeElements) {
+        if (includeElements && !response.records().isEmpty()) {
             Set<String> codesModule = response.records().stream()
                                                         .map(ModuleResponse::getCodeModule)
                                                         .collect(Collectors.toSet());


### PR DESCRIPTION
- Add the name of the param in `@RequestParam` on the `getElementsByCodesModule` method of the `ElementClient`
- Check if the records are empty before retrieving the elements when including the modules' elements on the findAll method