### PR TITLE
include `filiere` in `semestre response`

### DIFF
--- a/filiere-service/src/main/java/ma/enset/filiereservice/contoller/FiliereController.java
+++ b/filiere-service/src/main/java/ma/enset/filiereservice/contoller/FiliereController.java
@@ -62,7 +62,7 @@ public class FiliereController {
 
     @GetMapping
     public ResponseEntity<FilierePagingResponse> getAll(@RequestParam(defaultValue = "0") @Min(0) int page,
-                                                        @RequestParam(defaultValue = "10") @Range(min = 1, max = 10) int size,
+                                                        @RequestParam(defaultValue = "10") @Range(min = 1, max = 100) int size,
                                                         @RequestParam(defaultValue = "") String searchByIntitute,
                                                         @RequestParam(defaultValue = "false") boolean includeDepartement,
                                                         @RequestParam(defaultValue = "false") boolean includeSemestre,

--- a/semestre-service/src/main/java/ma/enset/semestreservice/client/FiliereClient.java
+++ b/semestre-service/src/main/java/ma/enset/semestreservice/client/FiliereClient.java
@@ -1,18 +1,38 @@
 package ma.enset.semestreservice.client;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import ma.enset.semestreservice.dto.FiliereResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
 
+import java.util.List;
 import java.util.Set;
 
 @HttpExchange(url = "/api/v1/filieres")
 public interface FiliereClient {
-    @GetExchange(url="/{codeFiliere}")
-    ResponseEntity<Object> getFiliereById(@PathVariable("codeFiliere") String codeFiliere);
+    @GetExchange(url = "/{codeFiliere}")
+    ResponseEntity<FiliereResponse> getFiliereById(
+            @PathVariable("codeFiliere") String codeFiliere,
+            @RequestParam(name = "includeDepartement", defaultValue = "false") boolean includeDepartement,
+            @RequestParam(name = "includeSemestre", defaultValue = "false") boolean includeSemestre,
+            @RequestParam(name = "includeRegleDeCalcule", defaultValue = "false") boolean includeRegleDeCalcule,
+            @RequestParam(name = "includeChefFiliere", defaultValue = "false") boolean includeChefFiliere
+    );
 
-    @GetExchange(url="/bulk")
-    ResponseEntity<Object> getAllFilieresByIds(@RequestParam("codeFiliere") Set<String> codeFiliere);
+    @GetExchange(url = "/exists")
+    ResponseEntity<Void> existsAll(@RequestParam("codesFiliere") Set<String> codesFiliere);
+
+    @GetExchange(url = "/bulk")
+    ResponseEntity<List<FiliereResponse>> getAllFilieresByIds(
+            @RequestParam("codeFiliere") Set<String> codeFiliere,
+            @RequestParam(name = "includeDepartement", defaultValue = "false") boolean includeDepartement,
+            @RequestParam(name = "includeSemestre", defaultValue = "false") boolean includeSemestre,
+            @RequestParam(name = "includeRegleDeCalcule", defaultValue = "false") boolean includeRegleDeCalcule,
+            @RequestParam(name = "includeChefFiliere", defaultValue = "false") boolean includeChefFiliere
+    );
 }

--- a/semestre-service/src/main/java/ma/enset/semestreservice/controller/SemestreController.java
+++ b/semestre-service/src/main/java/ma/enset/semestreservice/controller/SemestreController.java
@@ -45,16 +45,18 @@ public class SemestreController {
 
     @GetMapping("/{codeSemestre}")
     public ResponseEntity<SemestreResponse> getById(@PathVariable String codeSemestre,
+                                                    @RequestParam(defaultValue = "false") boolean includeFiliere,
                                                     @RequestParam(defaultValue = "false") boolean includeModules) {
 
-        return ResponseEntity.ok(service.findById(codeSemestre, includeModules));
+        return ResponseEntity.ok(service.findById(codeSemestre, includeFiliere, includeModules));
     }
 
     @GetMapping("/bulk")
     public ResponseEntity<List<SemestreResponse>> getAllByIds(@RequestParam Set<String> codesSemestre,
+                                                              @RequestParam(defaultValue = "false") boolean includeFiliere,
                                                               @RequestParam(defaultValue = "false") boolean includeModules) {
 
-        return ResponseEntity.ok(service.findAllByIds(codesSemestre, includeModules));
+        return ResponseEntity.ok(service.findAllByIds(codesSemestre, includeFiliere, includeModules));
     }
 
     @GetMapping("/filiere/{codeFiliere}")
@@ -70,9 +72,10 @@ public class SemestreController {
     @GetMapping
     public ResponseEntity<SemestrePagingResponse> getAll(@RequestParam(defaultValue = "0") @Min(0) int page,
                                                          @RequestParam(defaultValue = "10") @Range(min = 1, max = 100) int size,
+                                                         @RequestParam(defaultValue = "false") boolean includeFiliere,
                                                          @RequestParam(defaultValue = "false") boolean includeModules) {
 
-        return ResponseEntity.ok(service.findAll(page, size, includeModules));
+        return ResponseEntity.ok(service.findAll(page, size, includeFiliere, includeModules));
     }
 
     @PatchMapping("/{codeSemestre}")
@@ -89,7 +92,7 @@ public class SemestreController {
     }
 
     @DeleteMapping("/bulk")
-    public ResponseEntity<Void> deleteAllByIds(@RequestBody @NotEmpty Set<@NotBlank String> codesSemestre) {
+    public ResponseEntity<Void> deleteAllByIds(@RequestParam @NotEmpty Set<@NotBlank String> codesSemestre) {
         service.deleteAllByIds(codesSemestre);
         return ResponseEntity.noContent().build();
     }

--- a/semestre-service/src/main/java/ma/enset/semestreservice/dto/FiliereResponse.java
+++ b/semestre-service/src/main/java/ma/enset/semestreservice/dto/FiliereResponse.java
@@ -1,0 +1,22 @@
+package ma.enset.semestreservice.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+import java.util.List;
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Setter
+@Getter
+@Data
+public class FiliereResponse {
+    private String codeFiliere;
+    private String intituleFiliere;
+    private String codeDepartement;
+    private String codeChefFiliere;
+    private String codeRegleDeCalcul;
+
+}

--- a/semestre-service/src/main/java/ma/enset/semestreservice/dto/SemestreResponse.java
+++ b/semestre-service/src/main/java/ma/enset/semestreservice/dto/SemestreResponse.java
@@ -1,10 +1,7 @@
 package ma.enset.semestreservice.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -20,13 +17,17 @@ public class SemestreResponse {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<Module> modules;
-
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private FiliereResponse filiere;
 
     @Builder
-    public record Module (
-        String codeModule,
-        String intituleModule,
-        BigDecimal coefficientModule,
-        String codeSemestre
-    ) {}
+    public record Module(
+            String codeModule,
+            String intituleModule,
+            BigDecimal coefficientModule,
+            String codeSemestre
+    ) {
+    }
+
+
 }

--- a/semestre-service/src/main/java/ma/enset/semestreservice/service/SemestreService.java
+++ b/semestre-service/src/main/java/ma/enset/semestreservice/service/SemestreService.java
@@ -15,11 +15,11 @@ public interface SemestreService {
 
     boolean existAllByIds(Set<String> codesSemestre) throws ElementNotFoundException;
 
-    SemestreResponse findById(String codeSemestre, boolean includeModules) throws ElementNotFoundException;
+    SemestreResponse findById(String codeSemestre, boolean includeFiliere, boolean includeModules) throws ElementNotFoundException;
 
-    List<SemestreResponse> findAllByIds(Set<String> codesSemestre, boolean includeModules) throws ElementNotFoundException;
+    List<SemestreResponse> findAllByIds(Set<String> codesSemestre, boolean includeFiliere, boolean includeModules) throws ElementNotFoundException;
 
-    SemestrePagingResponse findAll(int page, int size, boolean includeModules);
+    SemestrePagingResponse findAll(int page, int size, boolean includeFiliere, boolean includeModules);
 
     List<SemestreResponse> findAllByCodeFiliere(String codeFiliere);
 


### PR DESCRIPTION
Added the option to include the filiere in the semestre response, so that the frontend can have complete information about a filiere without making additional API calls.